### PR TITLE
Include <stdint.h> where needed

### DIFF
--- a/amadec/audio-dec.h
+++ b/amadec/audio-dec.h
@@ -12,6 +12,7 @@
 #define AUDIO_DEC_H
 
 #include<pthread.h>
+#include <stdint.h>
 
 #include <audio-out.h>
 #include <audiodsp.h>

--- a/amavutils/include/Amvideoutils.h
+++ b/amavutils/include/Amvideoutils.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #define HDMI_HDCP_PASS           (1)
 #define HDMI_HDCP_FAILED      (0)
 #define HDMI_NOCONNECT        (-1)


### PR DESCRIPTION
The {u,}int{8,16,32}_t types are defined in <stdint.h>, so it should be
included when such types are used.

Not including <stdint.h> might work by accident with some C libraries
due to it being included by other headers, but it for example causes
build failures with the musl C library.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
