### PR TITLE
c2_aml_lib: change the amcodec header files installation path

### DIFF
--- a/amcodec/Makefile
+++ b/amcodec/Makefile
@@ -60,6 +60,6 @@ clean:$(CLRDIR)
 
 install:$(target_all)
 	-install  -m 755   $(TARGET)  $(INSTALL_DIR)
-	cp  -rf $(SRC)/include/*  $(HEADERS_DIR)/
+	cp  -rf $(SRC)/include/  $(HEADERS_DIR)/amcodec
 
 


### PR DESCRIPTION
Lots of application use this amcodec header path.
